### PR TITLE
Removed verbose logging and fixed cleanDbs()

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ function updateSchedule(){
 
                     db.cleanDbs()
                         .then(r => {
-                            stdOutLogger('Removed old content from databases');
+                            if(r) stdOutLogger('Removed old content from databases');
                         })
                         .catch(e => stdOutLogger(e, 1));
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -256,9 +256,12 @@ export class mongodb {
                                films.push(element);
                             });
 
-                            // remove outdated sessions
+                            // remove outdated sessions (db uses GMT so use one day back as filter to avoid removing current day shows after 5PM)
                             let d = ((getISOlocaleString()).split('T', 1))[0];
-                            await sessionsdb.deleteMany({date: {$lt: d}});
+                            let day = parseInt((d.split('-', 3))[2]) - 1;
+                            let date = (d.split('-', 3)[0]) + '-' + (d.split('-', 3)[1]) + '-' + day.toString();
+
+                            await sessionsdb.deleteMany({date: {$lt: date}});
 
                             let sCursor = sessionsdb.find();
                             let sessions = [];
@@ -287,9 +290,12 @@ export class mongodb {
                             }
 
                             db.close();
-                            resolve({
-                                status: 'OK'
-                            });
+                            if(result){
+                                resolve(result);
+                            }
+                            else{
+                                resolve();
+                            }
                         
                         
                         }


### PR DESCRIPTION
Set filter to go one business day back for removing sessions from db.  Database uses GMT and so was removing sessions starting after 5PM on the current business day.  This update corrects that issue.  

Also removed unnecessary logging output from cleanDbs()